### PR TITLE
Fixed Wiki Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@
 
 ## Help
 
-Please see [the wiki](https://github.com/Smashing-Tech/Smash-Hit-Blender-Tools/wiki) for information about how to use the addon, as well as some technical information about Smash Hit and the mesh baker.
+Please see [the wiki](https://github.com/Shatter-Team/Shatter/wiki) for information about how to use the addon, as well as some technical information about Smash Hit and the mesh baker.


### PR DESCRIPTION
This is the simplest change that the entire GitHub has never seen but it simply fixes the Wiki Link in the README file replacing that one from the old repo from the new updated one from this new Shatter Repository